### PR TITLE
Make `surfacepatch` in example 1 more general

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TMI"
 uuid = "582500f6-28c8-4d8f-aabe-b197735ec1d4"
 authors = ["G Jake Gebbie <ggebbie@whoi.edu>"]
-version = "0.2.16"
+version = "0.2.17"
 
 [deps]
 COSMO = "1e616198-aa4e-51ec-90a2-23f7fbd31d8d"

--- a/scripts/ex1.trackpathways.jl
+++ b/scripts/ex1.trackpathways.jl
@@ -32,7 +32,7 @@ c = trackpathways(Alu,latbox,lonbox,γ);
 plotbox(latbox, lonbox)
 
 # plot a section at 330 east longitude (i.e., 30 west)
-lon_section = 330; # only works if exact
+lon_section = 330; # only works if exactly matches a grid longitude (CAUTION!)
 lims = 0:5:100
 tlabel = "water-mass fraction [%]"
 sectionplot(100c,lon_section,lims,titlelabel = tlabel) # heat colormap would be better


### PR DESCRIPTION
- extend usage to nordic case
- fix bug related to incompatible wraparound longitude on grid

approach: shift grid longitudes to be centered around the surface patch of interest