### PR TITLE
bugfix meta-data passthrough `ones`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TMI"
 uuid = "582500f6-28c8-4d8f-aabe-b197735ec1d4"
 authors = ["G Jake Gebbie <ggebbie@whoi.edu>"]
-version = "0.2.21"
+version = "0.2.22"
 
 [deps]
 COSMO = "1e616198-aa4e-51ec-90a2-23f7fbd31d8d"

--- a/src/boundary_condition.jl
+++ b/src/boundary_condition.jl
@@ -210,7 +210,7 @@ function ones(dim::I,dimval::I,γ::Grid,name::Symbol,longname::String,units::Str
     tracer = Array{Float64}(undef,size(wet))
     tracer[wet] .= ones(Float64)
     tracer[.!wet] .= zero(Float64)/zero(Float64)
-    return BoundaryCondition(tracer,baxes,k,dim,dimval,wet)
+    return BoundaryCondition(tracer,baxes,k,dim,dimval,wet,name,longname,units)
 end
 
 """


### PR DESCRIPTION
Boundary Condition constructor was not passing through the units, names, etc.