### PR TITLE
Increasing documentation size threshhold

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://ggebbie.github.io/TMI.jl",
         assets=String[],
+        size_threshold = 250 * 2^10,
     ),
     pages=[
         "Top-level functions" => "index.md",


### PR DESCRIPTION
Default it 200KiB. Updating to 250 KiB.